### PR TITLE
When trying to use sha1 in an ember application is complained about missing arguments

### DIFF
--- a/sha1.js
+++ b/sha1.js
@@ -121,7 +121,10 @@
 
     // support AMD and Node
     if(typeof define === "function" && typeof define.amd){
-        define(function(){
+        define(
+          "sha1",
+          [],
+          function(){
             return sha1;
         });
     }else if(typeof exports !== 'undefined') {


### PR DESCRIPTION
This pull request adds the two optional arguments to AMD that ember causes ember to not build unless they are there.