### PR TITLE
Removed typeof statement, that was root cause of problem with imports.

### DIFF
--- a/sha1.js
+++ b/sha1.js
@@ -120,11 +120,8 @@
     }
 
     // support AMD and Node
-    if(typeof define === "function" && typeof define.amd){
-        define(
-          "sha1",
-          [],
-          function(){
+    if(typeof define === "function" && define.amd){
+        define(function(){
             return sha1;
         });
     }else if(typeof exports !== 'undefined') {


### PR DESCRIPTION
In AMD API specification, id and dependencies are optional parameters. Problem was caused by this condition:

`if(typeof define === "function" && typeof define.amd){`

`typeof define.amd` always returned non-empty string (which is evaluated as true value), so whole condition was actually checking if function define is defined - not if that is actuall amd define.